### PR TITLE
Add files via upload - Search articles through NYtimes api

### DIFF
--- a/Newyork_times_article_api.ipynb
+++ b/Newyork_times_article_api.ipynb
@@ -1,0 +1,97 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qChxfevX6ais"
+      },
+      "outputs": [],
+      "source": [
+        "import requests\n",
+        "import csv\n",
+        "import time\n",
+        "\n",
+        "def retrieve_articles(api_key, query, num_articles):\n",
+        "    articles = []\n",
+        "    page = 0\n",
+        "    while len(articles) < num_articles:\n",
+        "        url = \"https://api.nytimes.com/svc/search/v2/articlesearch.json\"\n",
+        "        params = {\n",
+        "            \"q\": query,\n",
+        "            \"api-key\": api_key,\n",
+        "            \"page\": page\n",
+        "        }\n",
+        "\n",
+        "        response = requests.get(url, params=params)\n",
+        "\n",
+        "        if response.status_code == 200:\n",
+        "            results = response.json()[\"response\"][\"docs\"]\n",
+        "            if len(results) == 0:\n",
+        "                break\n",
+        "            articles.extend(results)\n",
+        "            page += 1\n",
+        "        elif response.status_code == 429:\n",
+        "            print(\"Rate limit exceeded. Waiting and retrying...\")\n",
+        "            time.sleep(60)  # Wait for 60 seconds before retrying\n",
+        "        else:\n",
+        "            print(\"Error occurred while retrieving articles:\", response.status_code)\n",
+        "            break\n",
+        "\n",
+        "    return articles[:num_articles]\n",
+        "\n",
+        "def save_to_csv(articles, filename):\n",
+        "    with open(filename, 'w', newline='', encoding='utf-8') as csvfile:\n",
+        "        fieldnames = ['headline', 'web_url', 'pub_date', 'abstract']\n",
+        "        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)\n",
+        "\n",
+        "        writer.writeheader()\n",
+        "        for article in articles:\n",
+        "            writer.writerow({'headline': article[\"headline\"][\"main\"],\n",
+        "                             'web_url': article[\"web_url\"],\n",
+        "                             'pub_date': article[\"pub_date\"],\n",
+        "                             'abstract': article[\"abstract\"]})\n",
+        "\n",
+        "# Replace 'YOUR_API_KEY' with your actual New York Times API key\n",
+        "api_key = 'CZm0kVm8LZoyPkhwSm42ef74Ry15ywGG'\n",
+        "\n",
+        "# Replace 'YOUR_QUERY' with your search query\n",
+        "query = 'YOUR_QUERY'\n",
+        "\n",
+        "# Number of articles you want to fetch\n",
+        "num_articles = 4000\n",
+        "\n",
+        "articles = retrieve_articles(api_key, query, num_articles)\n",
+        "if articles:\n",
+        "    csv_filename = 'nytimes_articles.csv'\n",
+        "    save_to_csv(articles, csv_filename)\n",
+        "    print(\"Articles saved to\", csv_filename, \"successfully!\")\n",
+        "else:\n",
+        "    print(\"No articles found.\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "wRPS1TDG6eRx"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Here is a code to get articles from New York times api as well as converting it into a Csv file for easy use. 

the initial code provided to this doesn't work for me, I keep getting this error :{"fault":{"faultstring":"Invalid ApiKey","detail":{"errorcode":"oauth.v2.InvalidApiKey"}}}

So i came up with this.